### PR TITLE
7 remove manual truncation due to fixed kiddo bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1359,8 +1359,7 @@ dependencies = [
 [[package]]
 name = "kiddo"
 version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d2f8d9e1bc7c6919ad2cdc83472a9a4b5ed2ea2c5392c9514fdf958a7920f9a"
+source = "git+https://github.com/sdd/kiddo.git?rev=cc62c6d76accdeba75c0f55db80c28eab8a21ae7#cc62c6d76accdeba75c0f55db80c28eab8a21ae7"
 dependencies = [
  "az",
  "divrem",

--- a/geoprox-core/CHANGELOG.md
+++ b/geoprox-core/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Moved configuration defaults into `GeoShard` ([#2](https://github.com/ezrasingh/geoprox/issues/2)).
+- Remove [manual truncation in unsorted search](https://github.com/ezrasingh/geoprox/blob/f2074652e7b0e5eb8a4f0ae9bd4cb9f3c0c621df/geoprox-core/src/cache.rs#L175) by pinning Kiddo to latest commit ([#7](https://github.com/ezrasingh/geoprox/issues/7)) and handling edge case with `count` = 0.
 
 ## 0.4.0
 

--- a/geoprox-core/Cargo.toml
+++ b/geoprox-core/Cargo.toml
@@ -16,7 +16,9 @@ geohash = "0.13.1"
 hashbrown = { version = "0.14.5", features = ["serde", "rayon"] }
 haversine = "0.2.1"
 itertools = "0.13.0"
-kiddo = { version = "4.2.0", features = ["serialize"] }
+kiddo = { git = "https://github.com/sdd/kiddo.git", rev = "cc62c6d76accdeba75c0f55db80c28eab8a21ae7", features = [
+    "serialize",
+] }
 log = "0.4.22"
 patricia_tree = { version = "0.8.0", features = ["serde"] }
 rayon = "1.10.0"

--- a/geoprox-core/README.md
+++ b/geoprox-core/README.md
@@ -33,6 +33,7 @@ extern crate geoprox_core;
 let mut geo_index = geoprox_core::SpatialIndex::default();
 
 // ? place object keys into index
+let insert_depth = 6; // insert precision (higher means objects get grouped into bigger regions)
 geo_index.insert("alice", &geohash::encode([40.7129, 74.007].into(), depth).unwrap());
 geo_index.insert("bob", &geohash::encode([40.7127, 74.005].into(), depth).unwrap());
 
@@ -41,8 +42,8 @@ let nearby: LatLngCoord = [40.7128, 74.006];
 let within: f64 = 200.0; // 200km radius
 let count = 100; // return up to 100 results
 let sorted = true; // sort results by distance
-let depth = 6; // ? determines geohash length (i.e precision)
-let res = geo_index.search(nearby, within, count, sorted, Some(depth)).unwrap();
+let search_depth = 6; // search precision (higher means more precise)
+let res = geo_index.search(nearby, within, count, sorted, depth).unwrap();
 
 println!("found: {:#?}", res);
 
@@ -63,6 +64,7 @@ Key features include:
 - **Inserting Keys**: Insert keys into the geospatial index with their corresponding locations.
 - **Querying Ranges**: Query the index to find keys within a specified range from a given location.
 - **Drop Index**: Deletes the index and its associated keys.
+- **Batch Commands**: Insert, Remove or Query objects in bulk.
 
 #### Example Usage
 
@@ -82,7 +84,7 @@ let nearby: LatLngCoord = [36.2048, 138.2529];
 let within: f64 = 50.0; // 50km radius
 let count = 100; // return up to 100 results
 let sorted = true; // sort results by distance
-let res = shard.query_range("drivers", nearby, within, count, sorted).unwrap();
+let res = shard.query_range("drivers", nearby, within, Some(count), Some(sorted)).unwrap();
 
 println!("found: {:#?}", res);
 ```

--- a/geoprox-core/src/cache.rs
+++ b/geoprox-core/src/cache.rs
@@ -136,7 +136,7 @@ impl SpatialIndex {
         sorted: bool,
         search_depth: usize,
     ) -> Result<Vec<Neighbor>, GeohashError> {
-        if self.position_map.is_empty() {
+        if self.position_map.is_empty() || count.eq(&0) {
             return Ok(vec![]);
         }
         let search_region: String = {
@@ -297,13 +297,11 @@ mod test {
     }
 
     #[test]
-    fn test_search_count_unsorted() {
+    fn test_search_sorted_count() {
         // ? see, https://github.com/sdd/kiddo/issues/168
         let mut geo_index = SpatialIndex::default();
         let depth: usize = 6;
         let range = 1000.0;
-        let count = 0;
-        let sorted = false;
         let origin: LatLngCoord = [0.0, 0.0];
 
         geo_index.insert_many(vec![
@@ -317,10 +315,29 @@ mod test {
             ("h".to_string(), encode_lat_lng([0.0, 0.0], depth)),
         ]);
 
-        let res = geo_index
-            .search(origin, range, count, sorted, DEFAULT_DEPTH)
+        let count = 1;
+
+        let res_sorted = geo_index
+            .search(origin, range, count, true, DEFAULT_DEPTH)
             .unwrap();
-        assert_eq!(res.len(), 0);
+        let res_unsorted = geo_index
+            .search(origin, range, count, false, DEFAULT_DEPTH)
+            .unwrap();
+
+        assert_eq!(res_sorted.len(), count);
+        assert_eq!(res_unsorted.len(), count);
+
+        let count = 0;
+
+        let res_sorted = geo_index
+            .search(origin, range, count, true, DEFAULT_DEPTH)
+            .unwrap();
+        let res_unsorted = geo_index
+            .search(origin, range, count, false, DEFAULT_DEPTH)
+            .unwrap();
+
+        assert_eq!(res_sorted.len(), count);
+        assert_eq!(res_unsorted.len(), count);
     }
 
     #[test]

--- a/geoprox-core/src/shard.rs
+++ b/geoprox-core/src/shard.rs
@@ -228,40 +228,6 @@ mod test {
     }
 
     #[test]
-    fn test_query_range_sorted() {
-        let mut shard = GeoShard::default();
-        let mock_index = "mock-index";
-        let count = Some(100);
-        let sorted = None;
-        shard.create_index(mock_index).unwrap();
-
-        shard
-            .insert_many_keys(
-                mock_index,
-                vec![
-                    ("a".to_string(), [0.0, 1.0]),
-                    ("b".to_string(), [1.0, 0.5]),
-                    ("c".to_string(), [0.0, 0.0]),
-                    ("d".to_string(), [0.0, -1.0]),
-                    ("e".to_string(), [-1.0, -0.5]),
-                    ("f".to_string(), [0.0, 0.0]),
-                ],
-                false,
-            )
-            .unwrap();
-
-        let res = shard
-            .query_range(mock_index, [0.0, 0.0], 150.0, count, sorted)
-            .unwrap();
-
-        let mut sorted_neighbors = res.to_vec();
-
-        sorted_neighbors.sort_by(|a, b| a.distance.partial_cmp(&b.distance).unwrap());
-
-        assert_eq!(res, sorted_neighbors);
-    }
-
-    #[test]
     fn test_query_range_count() {
         let mut shard = GeoShard::default();
         let mock_index = "mock-index";
@@ -286,7 +252,7 @@ mod test {
         {
             let count = Some(100);
             let res = shard
-                .query_range(mock_index, [0.0, 0.0], 150.0, count, sorted)
+                .query_range(mock_index, [0.0, 0.0], 1000.0, count, sorted)
                 .unwrap();
 
             assert!(res.len() <= count.unwrap());
@@ -296,10 +262,44 @@ mod test {
             let count = Some(0);
 
             let res = shard
-                .query_range(mock_index, [0.0, 0.0], 150.0, count, sorted)
+                .query_range(mock_index, [0.0, 0.0], 1000.0, count, sorted)
                 .unwrap();
 
             assert!(res.len() <= count.unwrap());
         }
+    }
+
+    #[test]
+    fn test_query_range_sorted() {
+        let mut shard = GeoShard::default();
+        let mock_index = "mock-index";
+        let count = Some(100);
+        let sorted = Some(true);
+        shard.create_index(mock_index).unwrap();
+
+        shard
+            .insert_many_keys(
+                mock_index,
+                vec![
+                    ("a".to_string(), [0.0, 1.0]),
+                    ("b".to_string(), [1.0, 0.5]),
+                    ("c".to_string(), [0.0, 0.0]),
+                    ("d".to_string(), [0.0, -1.0]),
+                    ("e".to_string(), [-1.0, -0.5]),
+                    ("f".to_string(), [0.0, 0.0]),
+                ],
+                false,
+            )
+            .unwrap();
+
+        let res = shard
+            .query_range(mock_index, [0.0, 0.0], 1000.0, count, sorted)
+            .unwrap();
+
+        let mut sorted_neighbors = res.to_vec();
+
+        sorted_neighbors.sort_by(|a, b| a.distance.partial_cmp(&b.distance).unwrap());
+
+        assert_eq!(res, sorted_neighbors);
     }
 }

--- a/geoprox-core/src/shard.rs
+++ b/geoprox-core/src/shard.rs
@@ -224,7 +224,7 @@ mod test {
         let res = shard
             .query_range(mock_index, [0.0, 0.0], 150.0, count, sorted)
             .unwrap();
-        assert_eq!(res.len(), 2);
+        assert_eq!(res.len(), count.unwrap());
     }
 
     #[test]

--- a/geoprox-core/src/shard.rs
+++ b/geoprox-core/src/shard.rs
@@ -224,7 +224,7 @@ mod test {
         let res = shard
             .query_range(mock_index, [0.0, 0.0], 150.0, count, sorted)
             .unwrap();
-        assert_eq!(res.len(), count.unwrap());
+        assert!(res.len() <= count.unwrap());
     }
 
     #[test]


### PR DESCRIPTION
### Description

This PR introduces a new test to handle edge cases when querying for `SpatialIndex::search`. The test is designed to ensure that the `search` function behaves as expected, particularly with the `count` and `sorted` parameters.

#### Key Changes:
- The test covers scenarios with both non-zero and zero values for `count`, verifying that the function returns the correct number of results when sorted or unsorted.
